### PR TITLE
Add TaskMax in Nomad systemd template

### DIFF
--- a/templates/nomad.systemd.erb
+++ b/templates/nomad.systemd.erb
@@ -12,6 +12,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 RestartSec=42s
 LimitNOFILE=131072
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To fix the problem that Nomad couldn't allocate more job in the worker due to task limit in systemd config.

https://github.com/hashicorp/nomad/pull/5306