### PR TITLE
Update Nomad systemd template to v0.9.1

### DIFF
--- a/templates/nomad.systemd.erb
+++ b/templates/nomad.systemd.erb
@@ -9,9 +9,14 @@ Group=<%= scope.lookupvar('nomad::group') %>
 ExecStart=<%= scope.lookupvar('nomad::bin_dir') %>/nomad agent \
   -config=<%= scope.lookupvar('nomad::config_dir') %> <%= scope.lookupvar('nomad::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 KillSignal=SIGINT
-RestartSec=42s
-LimitNOFILE=131072
+LimitNOFILE=infinity
+LimitNPROC=infinity
+Restart=on-failure
+RestartSec=2
+StartLimitBurst=3
+StartLimitIntervalSec=10
 TasksMax=infinity
 
 [Install]


### PR DESCRIPTION
The current systemd config template is not aligned with latest Nomad v.0.9.1, so I update its content.